### PR TITLE
[01/12] 생명 UI 추가

### DIFF
--- a/Assets/Scenes/main.unity
+++ b/Assets/Scenes/main.unity
@@ -319,6 +319,90 @@ MonoBehaviour:
   PlayerRigidBody: {fileID: 108670935}
   PlayerAnimator: {fileID: 108670932}
   PlayerCollider: {fileID: 108670936}
+--- !u!1 &266187563
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 266187564}
+  - component: {fileID: 266187565}
+  m_Layer: 0
+  m_Name: start_button
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &266187564
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 266187563}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.68, z: 0.063845746}
+  m_LocalScale: {x: 5.369, y: 5.369, z: 5.369}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1365292842}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &266187565
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 266187563}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 6613261f8803b1a41a803ef97b5560db, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1.08, y: 0.24}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1 &360180991
 GameObject:
   m_ObjectHideFlags: 0
@@ -349,10 +433,13 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   State: 0
+  Lives: 3
   IntroUI: {fileID: 1903470382}
+  DeadUI: {fileID: 1365292841}
   EnemySpawner: {fileID: 1400447447}
   FoodSpawner: {fileID: 1178974810}
   GoldenSpawner: {fileID: 418244395}
+  PlayerScript: {fileID: 0}
 --- !u!4 &360180993
 Transform:
   m_ObjectHideFlags: 0
@@ -950,6 +1037,38 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   scrollSpeed: 0.2
   meshRenderer: {fileID: 1343529948}
+--- !u!1 &1365292841
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1365292842}
+  m_Layer: 0
+  m_Name: DeadUI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1365292842
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1365292841}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.24950682, y: 0.36489272, z: -0.063845746}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 266187564}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1400447447
 GameObject:
   m_ObjectHideFlags: 0
@@ -1389,3 +1508,4 @@ SceneRoots:
   - {fileID: 418244397}
   - {fileID: 360180993}
   - {fileID: 1903470383}
+  - {fileID: 1365292842}

--- a/Assets/Scripts/Game Manager.cs
+++ b/Assets/Scripts/Game Manager.cs
@@ -18,6 +18,7 @@ public class GameManager : MonoBehaviour
 
     [Header("References")]
     public GameObject IntroUI;
+    public GameObject DeadUI;
     public GameObject EnemySpawner;
     public GameObject FoodSpawner;
     public GameObject GoldenSpawner;
@@ -50,6 +51,7 @@ public class GameManager : MonoBehaviour
             EnemySpawner.SetActive(false);
             FoodSpawner.SetActive(false);
             GoldenSpawner.SetActive(false);
+            DeadUI.SetActive(true);
             State = GameState.Dead;
         }
         if (State == GameState.Dead && Input.GetKeyDown(KeyCode.Space))

--- a/Assets/Scripts/Heart.cs
+++ b/Assets/Scripts/Heart.cs
@@ -1,0 +1,23 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Heart : MonoBehaviour
+{
+    public Sprite OnHeart;
+    public Sprite OffHeart;
+    public int LiveNumber;
+    public SpriteRenderer SpriteRenderer;
+    void Start()
+    {
+        
+    }
+
+    void Update()
+    {
+        if (GameManager.Instance.Lives >= LiveNumber)
+            SpriteRenderer.sprite = OnHeart;
+        else
+            SpriteRenderer.sprite = OffHeart;
+    }
+}

--- a/Assets/Scripts/Heart.cs.meta
+++ b/Assets/Scripts/Heart.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5bb33287d898df6409537876ae71e061
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/delivery.png.meta
+++ b/Assets/Sprites/delivery.png.meta
@@ -48,7 +48,7 @@ TextureImporter:
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 30
+  spritePixelsToUnits: 20
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1

--- a/Assets/Sprites/halmoni.png.meta
+++ b/Assets/Sprites/halmoni.png.meta
@@ -48,7 +48,7 @@ TextureImporter:
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 25
+  spritePixelsToUnits: 20
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1

--- a/Assets/Sprites/heart_off.png.meta
+++ b/Assets/Sprites/heart_off.png.meta
@@ -48,7 +48,7 @@ TextureImporter:
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 100
+  spritePixelsToUnits: 20
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1

--- a/Assets/Sprites/heart_on.png.meta
+++ b/Assets/Sprites/heart_on.png.meta
@@ -48,7 +48,7 @@ TextureImporter:
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 100
+  spritePixelsToUnits: 20
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1


### PR DESCRIPTION
> SpriteRenderer
- 객체로 활용해서 하트 색상 변경

> 정렬
- 빈 게임 오브젝트 생성 > 정렬 대상을 자식으로 넣기 
- 빈 오브젝트에 Layout Group 컴포넌트 추가
- 참고: https://drybone-developer.tistory.com/50