### PR TITLE
[01/12] 플레잉 시간에 따른 난이도 설정

### DIFF
--- a/Assets/Scripts/BackgroundScroll.cs
+++ b/Assets/Scripts/BackgroundScroll.cs
@@ -18,7 +18,7 @@ public class NewBehaviourScript : MonoBehaviour
 
     void Update()
     { 
-        meshRenderer.material.mainTextureOffset += new Vector2(scrollSpeed * Time.deltaTime, 0);
+        meshRenderer.material.mainTextureOffset += new Vector2(scrollSpeed * GameManager.Instance.CalculateGameSpeed() / 20 * Time.deltaTime, 0);
 
     }
 }

--- a/Assets/Scripts/Game Manager.cs
+++ b/Assets/Scripts/Game Manager.cs
@@ -55,6 +55,15 @@ public class GameManager : MonoBehaviour
         }
     }
 
+    public float CalculateGameSpeed()
+    {
+        if (State != GameState.Playing)
+            return 30f;
+        float speed = 30f + 0.5f * Mathf.Floor(CalculateScore() / 10f);
+
+        return Mathf.Min(speed, 20f);
+    }
+
     int GetHighScore()
     {
         return PlayerPrefs.GetInt("highScore");

--- a/Assets/Scripts/Mover.cs
+++ b/Assets/Scripts/Mover.cs
@@ -13,6 +13,6 @@ public class Mover : MonoBehaviour
 
     void Update()
     {
-        transform.position += Vector3.left * moveSpeed * Time.deltaTime;
+        transform.position += Vector3.left * GameManager.Instance.CalculateGameSpeed() / 5 * Time.deltaTime;
     }
 }


### PR DESCRIPTION
- 플레잉 시간에 따라 모든 객체들의 이동속도를 점진적으로 증가시킴
  - 추후에는 변수로 관리해야 리팩토링 공수가 적게 들 것 같음